### PR TITLE
Generate sets as LinkedHashSet

### DIFF
--- a/fixture/src/main/kotlin/com/appmattus/kotlinfixture/resolver/IterableKTypeResolver.kt
+++ b/fixture/src/main/kotlin/com/appmattus/kotlinfixture/resolver/IterableKTypeResolver.kt
@@ -66,7 +66,7 @@ internal class IterableKTypeResolver : Resolver {
         return Unresolved.Unhandled
     }
 
-    private fun Context.populateCollection(obj: KType, collection: MutableCollection<Any?>): Any? {
+    private fun Context.populateCollection(obj: KType, collection: MutableCollection<Any?>): Any {
         val argType = obj.arguments.first().type!!
 
         repeat(configuration.repeatCount()) {
@@ -106,12 +106,12 @@ internal class IterableKTypeResolver : Resolver {
         AbstractQueue::class,
         PriorityQueue::class -> PriorityQueue()
 
-        java.util.AbstractSet::class,
-        Set::class,
         SortedSet::class,
         NavigableSet::class,
         TreeSet::class -> TreeSet()
 
+        java.util.AbstractSet::class,
+        Set::class,
         HashSet::class,
         LinkedHashSet::class -> LinkedHashSet()
 

--- a/fixture/src/test/kotlin/com/appmattus/kotlinfixture/FixtureInvokeTypeTest.kt
+++ b/fixture/src/test/kotlin/com/appmattus/kotlinfixture/FixtureInvokeTypeTest.kt
@@ -64,4 +64,19 @@ class FixtureInvokeTypeTest {
             assertEquals(String::class, it::class)
         }
     }
+
+    @Test
+    fun `can create Set`() {
+        val set = fixture<Set<A>>()
+
+        assertTrue(Set::class.isInstance(set))
+
+        set.forEach {
+            assertEquals(A::class, it::class)
+        }
+    }
+
+    data class A(
+        val string: String
+    )
 }


### PR DESCRIPTION
Fixes #84

Ensures Set doesn't require the underlying type to be Comparable