### PR TITLE
Ensure `@Serializable` generated constructor is filtered out

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -49,4 +49,8 @@ object Versions {
         const val testExtJunit = "1.1.5"
         const val testRunner = "1.5.2"
     }
+
+    object KotlinX {
+        const val serialization = "1.5.0"
+    }
 }

--- a/fixture/build.gradle.kts
+++ b/fixture/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     id("com.android.lint")
     id("com.vanniktech.maven.publish")
     id("org.jetbrains.dokka")
+    id("org.jetbrains.kotlin.plugin.serialization") version Versions.kotlin
 }
 
 apply(from = "$rootDir/gradle/scripts/jacoco.gradle.kts")
@@ -45,6 +46,8 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation(kotlin("test-junit"))
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:${Versions.mockitoKotlin}")
+
+    testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.KotlinX.serialization}")
 
     // Used for ComparisonTest
     @Suppress("GradleDependency")

--- a/fixture/src/main/kotlin/com/appmattus/kotlinfixture/decorator/constructor/ConstructorStrategy.kt
+++ b/fixture/src/main/kotlin/com/appmattus/kotlinfixture/decorator/constructor/ConstructorStrategy.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Appmattus Limited
+ * Copyright 2020-2023 Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,4 +28,13 @@ interface ConstructorStrategy {
      * Returns [obj] constructors in the order to try when generating an instance.
      */
     fun constructors(context: Context, obj: KClass<*>): Collection<KFunction<*>>
+
+    /**
+     * Constructors of the class with Serializable constructors filtered out
+     */
+    val KClass<*>.filteredConstructors: Collection<KFunction<*>>
+        get() = constructors.filterNot { it.isSerializationConstructor() }
+
+    private fun KFunction<Any>.isSerializationConstructor(): Boolean =
+        (parameters.lastOrNull()?.type?.classifier as? KClass<*>)?.qualifiedName == "kotlinx.serialization.internal.SerializationConstructorMarker"
 }

--- a/fixture/src/main/kotlin/com/appmattus/kotlinfixture/decorator/constructor/ConstructorStrategy.kt
+++ b/fixture/src/main/kotlin/com/appmattus/kotlinfixture/decorator/constructor/ConstructorStrategy.kt
@@ -35,6 +35,8 @@ interface ConstructorStrategy {
     val KClass<*>.filteredConstructors: Collection<KFunction<*>>
         get() = constructors.filterNot { it.isSerializationConstructor() }
 
-    private fun KFunction<Any>.isSerializationConstructor(): Boolean =
-        (parameters.lastOrNull()?.type?.classifier as? KClass<*>)?.qualifiedName == "kotlinx.serialization.internal.SerializationConstructorMarker"
+    private fun KFunction<Any>.isSerializationConstructor(): Boolean {
+        val lastParameterType = (parameters.lastOrNull()?.type?.classifier as? KClass<*>)?.qualifiedName
+        return lastParameterType == "kotlinx.serialization.internal.SerializationConstructorMarker"
+    }
 }

--- a/fixture/src/main/kotlin/com/appmattus/kotlinfixture/decorator/constructor/GreedyConstructorStrategy.kt
+++ b/fixture/src/main/kotlin/com/appmattus/kotlinfixture/decorator/constructor/GreedyConstructorStrategy.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Appmattus Limited
+ * Copyright 2020-2023 Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,6 @@ import kotlin.reflect.KFunction
  */
 object GreedyConstructorStrategy : ConstructorStrategy {
     override fun constructors(context: Context, obj: KClass<*>): Collection<KFunction<*>> {
-        return obj.constructors.sortedByDescending { it.parameters.size }
+        return obj.filteredConstructors.sortedByDescending { it.parameters.size }
     }
 }

--- a/fixture/src/main/kotlin/com/appmattus/kotlinfixture/decorator/constructor/ModestConstructorStrategy.kt
+++ b/fixture/src/main/kotlin/com/appmattus/kotlinfixture/decorator/constructor/ModestConstructorStrategy.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Appmattus Limited
+ * Copyright 2020-2023 Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,6 @@ import kotlin.reflect.KFunction
  */
 object ModestConstructorStrategy : ConstructorStrategy {
     override fun constructors(context: Context, obj: KClass<*>): Collection<KFunction<*>> {
-        return obj.constructors.sortedBy { it.parameters.size }
+        return obj.filteredConstructors.sortedBy { it.parameters.size }
     }
 }

--- a/fixture/src/main/kotlin/com/appmattus/kotlinfixture/decorator/constructor/RandomConstructorStrategy.kt
+++ b/fixture/src/main/kotlin/com/appmattus/kotlinfixture/decorator/constructor/RandomConstructorStrategy.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Appmattus Limited
+ * Copyright 2020-2023 Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,6 @@ import kotlin.reflect.KFunction
  */
 object RandomConstructorStrategy : ConstructorStrategy {
     override fun constructors(context: Context, obj: KClass<*>): Collection<KFunction<*>> {
-        return obj.constructors.shuffled(context.random)
+        return obj.filteredConstructors.shuffled(context.random)
     }
 }

--- a/fixture/src/test/kotlin/com/appmattus/kotlinfixture/SerializableTest.kt
+++ b/fixture/src/test/kotlin/com/appmattus/kotlinfixture/SerializableTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appmattus.kotlinfixture
+
+import com.appmattus.kotlinfixture.config.TestGenerator.fixture
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+
+class SerializableTest {
+
+    @Serializable
+    private data class ErrorCodeDto(
+        val errorCode: String,
+        val errorDetail: String,
+        val errorDescription: String
+    )
+
+    @Test
+    fun `serializing and deserializing ErrorCodeDto should result in original instance`() {
+        repeat(100) {
+            val original = fixture<ErrorCodeDto>()
+            // Serializable generates synthetic constructors with nullable parameters so we ensure we verify we don't use that constructor
+            @Suppress("SENSELESS_COMPARISON")
+            runCatching {
+                require(original.errorCode != null)
+                require(original.errorDetail != null)
+                require(original.errorDescription != null)
+            }.onFailure {
+                println(original)
+                throw IllegalArgumentException()
+            }
+        }
+    }
+}


### PR DESCRIPTION
`@Serializable` annotated classes generate a constructor with nullable parameters which kotlinFixture will randomly pick. This PR filters constructors that contain the `SerializationConstructorMarker` so they are no longer picked.

Fixes #93 