### PR TITLE
Ensure Arrays of primitives are correctly generated

### DIFF
--- a/fixture/src/main/kotlin/com/appmattus/kotlinfixture/resolver/ArrayKTypeResolver.kt
+++ b/fixture/src/main/kotlin/com/appmattus/kotlinfixture/resolver/ArrayKTypeResolver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Appmattus Limited
+ * Copyright 2020-2023 Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.appmattus.kotlinfixture.resolver
 import com.appmattus.kotlinfixture.Context
 import com.appmattus.kotlinfixture.Unresolved
 import com.appmattus.kotlinfixture.Unresolved.Companion.createUnresolved
+import com.appmattus.kotlinfixture.typeOf
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.starProjectedType
@@ -26,7 +27,20 @@ import kotlin.reflect.full.starProjectedType
 internal class ArrayKTypeResolver : Resolver {
 
     @Suppress("ReturnCount")
-    override fun resolve(context: Context, obj: Any): Any? {
+    override fun resolve(context: Context, obj: Any): Any {
+        // Special handling for primitive arrays as Kotlin's KType seems to see Array<Int> as IntArray etc when looking at the classifier
+        // See https://youtrack.jetbrains.com/issue/KT-52170/Reflection-typeOfArrayLong-gives-classifier-LongArray
+        when (obj) {
+            BooleanArrayKType -> return (context.resolve(BooleanArray::class) as BooleanArray).toTypedArray()
+            ByteArrayKType -> return (context.resolve(ByteArray::class) as ByteArray).toTypedArray()
+            DoubleArrayKType -> return (context.resolve(DoubleArray::class) as DoubleArray).toTypedArray()
+            FloatArrayKType -> return (context.resolve(FloatArray::class) as FloatArray).toTypedArray()
+            IntArrayKType -> return (context.resolve(IntArray::class) as IntArray).toTypedArray()
+            LongArrayKType -> return (context.resolve(LongArray::class) as LongArray).toTypedArray()
+            ShortArrayKType -> return (context.resolve(ShortArray::class) as ShortArray).toTypedArray()
+            CharArrayKType -> return (context.resolve(CharArray::class) as CharArray).toTypedArray()
+        }
+
         if (obj is KType && obj.classifier?.starProjectedType == Array<Any?>::class.starProjectedType) {
             val size = context.configuration.repeatCount()
 
@@ -47,5 +61,16 @@ internal class ArrayKTypeResolver : Resolver {
         }
 
         return Unresolved.Unhandled
+    }
+
+    companion object {
+        private val BooleanArrayKType = typeOf<Array<Boolean>>()
+        private val ByteArrayKType = typeOf<Array<Byte>>()
+        private val DoubleArrayKType = typeOf<Array<Double>>()
+        private val FloatArrayKType = typeOf<Array<Float>>()
+        private val IntArrayKType = typeOf<Array<Int>>()
+        private val LongArrayKType = typeOf<Array<Long>>()
+        private val ShortArrayKType = typeOf<Array<Short>>()
+        private val CharArrayKType = typeOf<Array<Char>>()
     }
 }

--- a/fixture/src/test/kotlin/com/appmattus/kotlinfixture/ArrayTest.kt
+++ b/fixture/src/test/kotlin/com/appmattus/kotlinfixture/ArrayTest.kt
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2023 Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appmattus.kotlinfixture
+
+import com.appmattus.kotlinfixture.config.TestGenerator.fixture
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * More robust testing around Array fixtures as we now have special handling for arrays of primitive types
+ * See https://youtrack.jetbrains.com/issue/KT-52170/Reflection-typeOfArrayLong-gives-classifier-LongArray
+ */
+@OptIn(ExperimentalUnsignedTypes::class)
+class ArrayTest {
+
+    @Test
+    fun arrayBoolean() {
+        assertIsRandom {
+            fixture<Array<Boolean>>().onEach {
+                assertTrue { Boolean::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayByte() {
+        assertIsRandom {
+            fixture<Array<Byte>>().onEach {
+                assertTrue { Byte::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayDouble() {
+        assertIsRandom {
+            fixture<Array<Double>>().onEach {
+                assertTrue { Double::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayFloat() {
+        assertIsRandom {
+            fixture<Array<Float>>().onEach {
+                assertTrue { Float::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayInt() {
+        assertIsRandom {
+            fixture<Array<Int>>().onEach {
+                assertTrue { Int::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayLong() {
+        assertIsRandom {
+            fixture<Array<Long>>().onEach {
+                assertTrue { Long::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayShort() {
+        assertIsRandom {
+            fixture<Array<Short>>().onEach {
+                assertTrue { Short::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayChar() {
+        assertIsRandom {
+            fixture<Array<Char>>().onEach {
+                assertTrue { Char::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayUByte() {
+        assertIsRandom {
+            fixture<Array<UByte>>().onEach {
+                assertTrue { UByte::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayUInt() {
+        assertIsRandom {
+            fixture<Array<UInt>>().onEach {
+                assertTrue { UInt::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayULong() {
+        assertIsRandom {
+            fixture<Array<ULong>>().onEach {
+                assertTrue { ULong::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayUShort() {
+        assertIsRandom {
+            fixture<Array<UShort>>().onEach {
+                assertTrue { UShort::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun booleanArray() {
+        assertIsRandom {
+            fixture<BooleanArray>().onEach {
+                assertTrue { Boolean::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun byteArray() {
+        assertIsRandom {
+            fixture<ByteArray>().onEach {
+                assertTrue { Byte::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun doubleArray() {
+        assertIsRandom {
+            fixture<DoubleArray>().onEach {
+                assertTrue { Double::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun floatArray() {
+        assertIsRandom {
+            fixture<FloatArray>().onEach {
+                assertTrue { Float::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun intArray() {
+        assertIsRandom {
+            fixture<IntArray>().onEach {
+                assertTrue { Int::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun longArray() {
+        assertIsRandom {
+            fixture<LongArray>().onEach {
+                assertTrue { Long::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun shortArray() {
+        assertIsRandom {
+            fixture<ShortArray>().onEach {
+                assertTrue { Short::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun charArray() {
+        assertIsRandom {
+            fixture<CharArray>().onEach {
+                assertTrue { Char::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun uByteArray() {
+        assertIsRandom {
+            fixture<UByteArray>().onEach {
+                assertTrue { UByte::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun uIntArray() {
+        assertIsRandom {
+            fixture<UIntArray>().onEach {
+                assertTrue { UInt::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun uLongArray() {
+        assertIsRandom {
+            fixture<ULongArray>().onEach {
+                assertTrue { ULong::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun uShortArray() {
+        assertIsRandom {
+            fixture<UShortArray>().onEach {
+                assertTrue { UShort::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayBooleanNullable() {
+        assertIsRandom {
+            fixture<Array<Boolean?>>().onEach {
+                assertTrue { it == null || Boolean::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayByteNullable() {
+        assertIsRandom {
+            fixture<Array<Byte?>>().onEach {
+                assertTrue { it == null || Byte::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayDoubleNullable() {
+        assertIsRandom {
+            fixture<Array<Double?>>().onEach {
+                assertTrue { it == null || Double::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayFloatNullable() {
+        assertIsRandom {
+            fixture<Array<Float?>>().onEach {
+                assertTrue { it == null || Float::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayIntNullable() {
+        assertIsRandom {
+            fixture<Array<Int?>>().onEach {
+                assertTrue { it == null || Int::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayLongNullable() {
+        assertIsRandom {
+            fixture<Array<Long?>>().onEach {
+                assertTrue { it == null || Long::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayShortNullable() {
+        assertIsRandom {
+            fixture<Array<Short?>>().onEach {
+                assertTrue { it == null || Short::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayCharNullable() {
+        assertIsRandom {
+            fixture<Array<Char?>>().onEach {
+                assertTrue { it == null || Char::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayUByteNullable() {
+        assertIsRandom {
+            fixture<Array<UByte?>>().onEach {
+                assertTrue { it == null || UByte::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayUIntNullable() {
+        assertIsRandom {
+            fixture<Array<UInt?>>().onEach {
+                assertTrue { it == null || UInt::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayULongNullable() {
+        assertIsRandom {
+            fixture<Array<ULong?>>().onEach {
+                assertTrue { it == null || ULong::class.isInstance(it) }
+            }
+        }
+    }
+
+    @Test
+    fun arrayUShortNullable() {
+        assertIsRandom {
+            fixture<Array<UShort?>>().onEach {
+                assertTrue { it == null || UShort::class.isInstance(it) }
+            }
+        }
+    }
+}

--- a/fixture/src/test/kotlin/com/appmattus/kotlinfixture/ComparisonTest.kt
+++ b/fixture/src/test/kotlin/com/appmattus/kotlinfixture/ComparisonTest.kt
@@ -196,8 +196,30 @@ class ComparisonTest {
             @Suppress("DEPRECATION_ERROR")
             val result = appmattus.create(type, appmattus.fixtureConfiguration)!!
 
-            assertTrue {
-                resultClass.isInstance(result)
+            // Special handling of primitive arrays due to bug in the Kotlin type system
+            // See https://youtrack.jetbrains.com/issue/KT-52170/Reflection-typeOfArrayLong-gives-classifier-LongArray
+            if (type in listOf(
+                    typeOf<Array<Boolean>>(),
+                    typeOf<Array<Byte>>(),
+                    typeOf<Array<Double>>(),
+                    typeOf<Array<Float>>(),
+                    typeOf<Array<Int>>(),
+                    typeOf<Array<Long>>(),
+                    typeOf<Array<Short>>(),
+                    typeOf<Array<Char>>()
+                )
+            ) {
+                val argumentType = type.arguments[0].type?.classifier as KClass<*>
+                assertTrue {
+                    result is Array<*>
+                }
+                (result as Array<*>).forEach {
+                    argumentType.isInstance(it)
+                }
+            } else {
+                assertTrue {
+                    resultClass.isInstance(result)
+                }
             }
         }
 
@@ -433,8 +455,18 @@ class ComparisonTest {
                 arrayOf(typeOf<UIntArray>(), VALID, VALID, VALID, VALID),
                 arrayOf(typeOf<ULongArray>(), VALID, VALID, VALID, VALID),
                 arrayOf(typeOf<UShortArray>(), VALID, VALID, VALID, VALID),
-                arrayOf(typeOf<Array<String>>(), VALID, VALID, UNSUPPORTED, VALID),
+                arrayOf(typeOf<Array<Boolean>>(), VALID, VALID, UNSUPPORTED, VALID),
+                arrayOf(typeOf<Array<Byte>>(), VALID, VALID, UNSUPPORTED, VALID),
+                arrayOf(typeOf<Array<Double>>(), VALID, VALID, UNSUPPORTED, VALID),
+                arrayOf(typeOf<Array<Float>>(), VALID, VALID, UNSUPPORTED, VALID),
                 arrayOf(typeOf<Array<Int>>(), VALID, VALID, UNSUPPORTED, VALID),
+                arrayOf(typeOf<Array<Long>>(), VALID, VALID, UNSUPPORTED, VALID),
+                arrayOf(typeOf<Array<Short>>(), VALID, VALID, UNSUPPORTED, VALID),
+                arrayOf(typeOf<Array<Char>>(), VALID, VALID, UNSUPPORTED, VALID),
+                arrayOf(typeOf<Array<UByte>>(), VALID, VALID, UNSUPPORTED, VALID),
+                arrayOf(typeOf<Array<UInt>>(), VALID, VALID, UNSUPPORTED, VALID),
+                arrayOf(typeOf<Array<ULong>>(), VALID, VALID, UNSUPPORTED, VALID),
+                arrayOf(typeOf<Array<UShort>>(), VALID, VALID, UNSUPPORTED, VALID),
 
                 // Iterable, List
                 arrayOf(typeOf<Iterable<String>>(), VALID, NOT_RANDOM, VALID, UNSUPPORTED),

--- a/fixture/src/test/kotlin/com/appmattus/kotlinfixture/resolver/ArrayKTypeResolverTest.kt
+++ b/fixture/src/test/kotlin/com/appmattus/kotlinfixture/resolver/ArrayKTypeResolverTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Appmattus Limited
+ * Copyright 2020-2023 Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,13 +42,6 @@ class ArrayKTypeResolverTest {
     @Test
     fun `Primitive array class returns Unresolved`() {
         val result = context.resolve(IntArray::class)
-
-        assertTrue(result is Unresolved)
-    }
-
-    @Test
-    fun `Array-Int class returns Unresolved`() {
-        val result = context.resolve(typeOf<Array<Int>>())
 
         assertTrue(result is Unresolved)
     }


### PR DESCRIPTION
Works around issues in Kotlins type system.

See https://youtrack.jetbrains.com/issue/KT-52170/Reflection-typeOfArrayLong-gives-classifier-LongArray

Fixes #92