### PR TITLE
Added helper function to immediately create an object fixture

### DIFF
--- a/fixture/src/main/kotlin/com/appmattus/kotlinfixture/KotlinFixture.kt
+++ b/fixture/src/main/kotlin/com/appmattus/kotlinfixture/KotlinFixture.kt
@@ -100,3 +100,8 @@ class Fixture @JvmOverloads constructor(val fixtureConfiguration: Configuration 
  */
 fun kotlinFixture(configuration: ConfigurationBuilder.() -> Unit = {}) =
     Fixture(ConfigurationBuilder().apply(configuration).build())
+
+inline fun <reified T> fixture(
+    range: Iterable<T> = emptyList(),
+    noinline configuration: ConfigurationBuilder.() -> Unit = {}
+) = kotlinFixture().invoke(range, configuration)


### PR DESCRIPTION
As discussed in https://github.com/appmattus/kotlinfixture/issues/98, it would be nice to have a small helper function that would immediately create a randomized fixture, without having to write:
```
kotlinFixture().invoke<MyType>()
```
each time.

This PR adds a new helper function to make ☝️ just look like:
```
fixture<MyType>()
```