### PR TITLE
Add property infix function

### DIFF
--- a/fixture/src/main/kotlin/com/appmattus/kotlinfixture/config/ConfigurationBuilder.kt
+++ b/fixture/src/main/kotlin/com/appmattus/kotlinfixture/config/ConfigurationBuilder.kt
@@ -583,6 +583,9 @@ class ConfigurationBuilder(configuration: Configuration = Configuration()) {
         return property(T::class, property.name, generator as GeneratorFun)
     }
 
+    @JvmName("propertyByInfixFunction")
+    inline infix fun <reified T, G> KProperty1<T, G>.property(noinline generator: Generator<G>.() -> G) = property(this, generator)
+
     /**
      * Customising generation of class properties with property
      *

--- a/fixture/src/test/kotlin/com/appmattus/kotlinfixture/config/ConfigurationBuilderTest.kt
+++ b/fixture/src/test/kotlin/com/appmattus/kotlinfixture/config/ConfigurationBuilderTest.kt
@@ -113,6 +113,25 @@ class ConfigurationBuilderTest {
     }
 
     @Test
+    fun `can override properties using property infix function`() {
+        val original: Generator<Properties>.() -> Properties = { Properties("2") }
+
+        @Suppress("UNCHECKED_CAST")
+        val configuration = ConfigurationBuilder(
+            Configuration(properties = mapOf(Properties::class to mapOf("property" to original as GeneratorFun)))
+        ).apply {
+            Properties::property property { "1" }
+        }.build()
+
+        with(TestGenerator) {
+            assertEquals(
+                "1",
+                (configuration.properties.getValue(Properties::class).getValue("property"))()
+            )
+        }
+    }
+
+    @Test
     fun `properties is immutable`() {
         val configuration = ConfigurationBuilder(Configuration()).build()
 


### PR DESCRIPTION
How about adding an infix function for the property function? This could allow for writing more readable code.